### PR TITLE
chore(deps): update dependencies and apply security fixes

### DIFF
--- a/cap/package-lock.json
+++ b/cap/package-lock.json
@@ -9,16 +9,16 @@
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cap-js-community/odata-v2-adapter": "^1.15.10",
-        "@cap-js/change-tracking": "^2.0.0-beta.11",
-        "@cap-js/graphql": "0.14.0",
+        "@cap-js-community/odata-v2-adapter": "^1.15.12",
+        "@cap-js/change-tracking": "^2.0.1",
+        "@cap-js/graphql": "^0.14.0",
         "@cap-js/hana": "^2.7.0",
-        "@cap-js/notifications": "0.3.0",
-        "@cap-js/ord": "1.6.0",
+        "@cap-js/notifications": "^0.3.0",
+        "@cap-js/ord": "^1.9.0",
         "@cap-js/postgres": "^2.2.0",
         "@cap-js/sqlite": "^2.2.0",
         "@cap-js/telemetry": "^1.6.0",
-        "@sap-cloud-sdk/resilience": "^4.6.0",
+        "@sap-cloud-sdk/resilience": "^4.7.0",
         "@sap/cds": "^9.9.1",
         "@sap/cds-common-content": "^3.1.0",
         "@sap/cds-fiori": "^2.3.0",
@@ -26,15 +26,15 @@
         "cds-swagger-ui-express": "^0.11.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.1"
       },
       "devDependencies": {
         "@cap-js/cds-test": "^1.0.1",
-        "@cap-js/cds-typer": ">=0.1",
+        "@cap-js/cds-typer": "^0.40.0",
         "@sap/dev-cap-tools": "^1.53.2",
-        "@sap/eslint-plugin-cds": "^4.2.1",
-        "@sap/hdi-deploy": "^5.6.1",
-        "eslint": "^10.3.0",
+        "@sap/eslint-plugin-cds": "^4.2.4",
+        "@sap/hdi-deploy": "^5.7.0",
+        "eslint": "^10.5.0",
         "stringify-changelog": "^0.2.1"
       },
       "engines": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@cap-js-community/odata-v2-adapter": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@cap-js-community/odata-v2-adapter/-/odata-v2-adapter-1.15.10.tgz",
-      "integrity": "sha512-Aig8AIf2zXxUV4imTYmhtZt0hl0nWlCM7ES5ZnY72juZAhT/h7v3reHEgS4CG95AiKqF7ZWolpEHMMA32QI4ZQ==",
+      "version": "1.15.12",
+      "resolved": "https://registry.npmjs.org/@cap-js-community/odata-v2-adapter/-/odata-v2-adapter-1.15.12.tgz",
+      "integrity": "sha512-EK4epS1BvZhgWwhOG/x5mlMIirEdo84NVadhtQITAdyDV0KLNFlfS6rzLYAf89ksb4Mdftr5ztmlXoq7uiMaKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^2.2.2",
@@ -60,10 +60,10 @@
       }
     },
     "node_modules/@cap-js/asyncapi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cap-js/asyncapi/-/asyncapi-1.0.3.tgz",
-      "integrity": "sha512-vZSWKAe+3qfvZDXV5SSFiObGWmqyS9MDyEADb5PLVT8kzO39qGaSDPv/GzI/gwvRfCayGAjU4ThiBKrFA7Gclg==",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/asyncapi/-/asyncapi-1.1.0.tgz",
+      "integrity": "sha512-ywO5NfGwoeEx6/jneOMpNMs4PFmuueet8HOEg13VAiXpu4W5juAZQ/Jv2xE0QcW9m1qiCmI1ymypmz7UI+YGbw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@sap/cds": ">=7.6"
       }
@@ -88,13 +88,16 @@
       }
     },
     "node_modules/@cap-js/cds-typer": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/cds-typer/-/cds-typer-0.38.0.tgz",
-      "integrity": "sha512-X/AAF3A02pNjxDQOpf+om0S+L1MWyFanz9/aQYwYvjUaaU/Tkx26ruziZ2MDbwVrAJ5iA6bSFYs6LP5/+oMdNQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/cds-typer/-/cds-typer-0.40.0.tgz",
+      "integrity": "sha512-8UWwa4q6DL1vRCq7KwwLXtLAHHkMI6HoPXsIXLVvRMaW11xvtSkMFHcaNjR8WBlccZTA7RWIqHavgKbq57zpKg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "cds-typer": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "@cap-js/cds-types": ">=0.9",
@@ -102,16 +105,15 @@
       }
     },
     "node_modules/@cap-js/cds-types": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/cds-types/-/cds-types-0.16.0.tgz",
-      "integrity": "sha512-xirqV7rVIAK8fNDZDjB4aFkHcKWTu0y9gs0WdS65fez9m3Zh+L+i3TndlhIJLT7XmlEYMeM6IEl8KyNIoIRBhw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/cds-types/-/cds-types-0.18.0.tgz",
+      "integrity": "sha512-2F4jI4USwDG8p78o2TXBWOLHUOyiQmdZe/7GKEqNHCOc1hjU5UgLY6AT1M3X5kG1fJRjUNui9jdnjlIchuZZtA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@sap/cds": ">=9.0.0",
-        "@sap/cds-dk": "^9",
+        "@sap/cds-dk": ">=9",
         "@types/express": ">=4"
       },
       "peerDependenciesMeta": {
@@ -121,12 +123,13 @@
       }
     },
     "node_modules/@cap-js/change-tracking": {
-      "version": "2.0.0-beta.11",
-      "resolved": "https://registry.npmjs.org/@cap-js/change-tracking/-/change-tracking-2.0.0-beta.11.tgz",
-      "integrity": "sha512-aFYVWKVfYhHZjsf/MDwIOEl+YWbk714rNJWPads/ZS0UGxbOSUEVJ6pzoI8eyLJBEOS9rjjmFHybPsd6GQiKIQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cap-js/change-tracking/-/change-tracking-2.0.1.tgz",
+      "integrity": "sha512-wqqt8HnVKQrWGicEe8G6fC8MbkTIfZbkScUE9O8vNq7mnKoYppTBO33DTmh3fVyUKoovVDmcGWbRf0f5prGHOw==",
       "license": "Apache-2.0",
       "workspaces": [
-        "tests/*"
+        "tests/*",
+        "tests/performance/"
       ],
       "engines": {
         "node": ">=20.0.0"
@@ -198,9 +201,9 @@
       }
     },
     "node_modules/@cap-js/openapi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/openapi/-/openapi-1.4.0.tgz",
-      "integrity": "sha512-/LRSwn4SDxAi3qKwl09zoOhEVGaPGlYOPz/0S3UBnaMJVvaLyPiKbbaOtOnrrgulUX5OXt+ujPIQznOsbTzuAw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/openapi/-/openapi-1.5.0.tgz",
+      "integrity": "sha512-JDzENNC80vnP9W31Skz6PfgPnpaxNTgIP8CtDK3bJ0FCbr5sXshRqes1pc17kNMXDbJAtEshS0dN7GYBW2THWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "pluralize": "^8.0.0"
@@ -210,9 +213,9 @@
       }
     },
     "node_modules/@cap-js/ord": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/ord/-/ord-1.6.0.tgz",
-      "integrity": "sha512-HLHtxhpezgEyYONBXhY5Eal+FDD9GhGIUGoBuPlF/+bndHsc+RTs5tZH6Nhvyz2u7agImk2uPMarjgxv4zlO1g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/ord/-/ord-1.9.0.tgz",
+      "integrity": "sha512-Xn6ONnciFpJKHbUgOgzhMT6hquDZa4B5J6Fo4OVDiut95z1cqzR/LhSXH4ZMsRHiS76PS7DXjKA0F6EYF27S6w==",
       "license": "Apache-2.0",
       "workspaces": [
         "xmpl",
@@ -370,9 +373,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -427,13 +430,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
-      "dev": true,
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -642,6 +645,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -657,6 +663,9 @@
       "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -674,6 +683,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,6 +701,9 @@
       "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -706,6 +721,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -722,6 +740,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,6 +758,9 @@
       "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1034,9 +1058,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -1112,21 +1136,21 @@
       }
     },
     "node_modules/@sap-cloud-sdk/resilience": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-4.6.0.tgz",
-      "integrity": "sha512-NMY683lNvJcE5dghVqUsBLM/voTLE6MMn5OmmB5BkG8qp5TZSuy/lhMZCVfGpBVnRLv6k19vWiBcueXxYg8bcQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-4.7.0.tgz",
+      "integrity": "sha512-L6PV49nNyZHnTNFbvaufadm+qOhaammXLXkDQmD7WIzMjhiYMqa/obK3NJoohe/kZ7q73jPB2vdLsAqopqTh0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sap-cloud-sdk/util": "^4.6.0",
+        "@sap-cloud-sdk/util": "^4.7.0",
         "async-retry": "^1.3.3",
         "axios": "^1.15.0",
         "opossum": "^9.0.0"
       }
     },
     "node_modules/@sap-cloud-sdk/resilience/node_modules/@sap-cloud-sdk/util": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-4.6.0.tgz",
-      "integrity": "sha512-z1gFjgzhAUhzPy1IkwWjfOrnPHh9KrEZbLlFBG5LbL3oBS3JMmKusW0162Hq4r+AVTR43akEoHxk07p247YQTw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-4.7.0.tgz",
+      "integrity": "sha512-nWJXMdM0Pcx/ipM2+5BvSciQKyCc0LAAO+acCOAQp65SA4HEQ2Odp9yxidY4ijW42TVp3fSMBvGwVjbWWx9Uew==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.15.0",
@@ -1188,9 +1212,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-6.9.0.tgz",
-      "integrity": "sha512-UXQ5pomb+Fw48Ch1mJoN1JkDy0loZX8nZKXjy4qxY2s9FMwNOwKJP9wPomAVlYcuzq6u8Viqh5j70ty8ciGWGg==",
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-6.9.3.tgz",
+      "integrity": "sha512-8fEeM6D059ruqLWoJqzFSNLkGoUCMnycx7Zv4OP4nA9zZeHzFC3nAe6s3ak2kASSiub1xAMMPzDE/9EnSXQKLw==",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "cdsc": "bin/cdsc.js",
@@ -1202,17 +1226,17 @@
       }
     },
     "node_modules/@sap/cds-dk": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds-dk/-/cds-dk-9.9.0.tgz",
-      "integrity": "sha512-gl2BOLhkyw9yFlNnX4ukl6dNEYDX7hVg+7QFUqlFTxcBU+tdQlFT8szk3NK77DkJkj1Xe+LZLJSe0crTtA32mw==",
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@sap/cds-dk/-/cds-dk-9.9.2.tgz",
+      "integrity": "sha512-cngXMULAuueITOLymme51fBuUKRaqofXDzwyJtnEQ2BLZBz/t6s+rXZV7nY2xJyqU3y0rbB023R9218D25evuw==",
       "hasShrinkwrap": true,
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "@cap-js/asyncapi": "^1.0.0",
         "@cap-js/openapi": "^1.0.0",
-        "@sap/cds": ">=8.3",
-        "@sap/cds-mtxs": ">=2",
+        "@sap/cds": "^8.3 || ^9",
+        "@sap/cds-mtxs": "^2 || ^3",
         "@sap/hdi-deploy": "^5",
         "express": "^4.22.1 || ^5",
         "hdb": "^2.0.0",
@@ -1241,8 +1265,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@cap-js/db-service": {
-      "version": "2.9.0",
-      "integrity": "sha512-WCXhoqezaF6A5I2l0MNZeHKXXtHRNEq7Rp0R89/uccOHQIx0DuU0U9NuJJPV/1G5RGk2QKQ9VBo/KYn+MZuuNQ==",
+      "version": "2.11.0",
+      "integrity": "sha512-sl33LcxZYAJgMCQZDw4lMGe4kWYq6685Xc6ze4qcoM+rd6aqiyVsSC6C7XH5yerXs7cVHhRC+Dgo8AsaapFzlQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -1254,8 +1278,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@cap-js/openapi": {
-      "version": "1.4.0",
-      "integrity": "sha512-/LRSwn4SDxAi3qKwl09zoOhEVGaPGlYOPz/0S3UBnaMJVvaLyPiKbbaOtOnrrgulUX5OXt+ujPIQznOsbTzuAw==",
+      "version": "1.4.2",
+      "integrity": "sha512-Mi02XsSlLy+h9tBLPX1/re2Obsmb1rnIj18AUb1jD5dLvbfedfDojtsuZIQHQImdYNeD6nMgaBQw0g1JRHTdow==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1266,13 +1290,13 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@cap-js/sqlite": {
-      "version": "2.2.0",
-      "integrity": "sha512-FPj+uVU/14vtGUl2P/Q8y7XhZbsLgrCav2O5PjHPXnupegjby4sMJkgVNxVHnkyKPFgO/W8uEsq9r5TU9VPx8w==",
+      "version": "2.4.0",
+      "integrity": "sha512-Ao+AzIN6BWHNpLbGxAzF79OezFNHzDG2srwiBABs0FYxIxEGkc2hg6ETo79pTTt66gcWtx7pWh/N9xk2M6SFBQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@cap-js/db-service": "^2.9.0",
+        "@cap-js/db-service": "^2.11.0",
         "better-sqlite3": "^12.0.0"
       },
       "peerDependencies": {
@@ -1306,8 +1330,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds": {
-      "version": "9.9.0",
-      "integrity": "sha512-09qkye9erBr71GNt6vdu9HmvZCKSTECYdxppQyAYJjeOeLJW4eL1eyZThawRkvqqLOEdmsEZdfG6eZ3X+w0YYA==",
+      "version": "9.9.1",
+      "integrity": "sha512-GqdsBsRkZThhpOyzj8ihf/jDmf/2zprZFgaun6ZymUw4/ahzjK/bbdd6eQ8txDuv88pnUl2HPFjvUVq3O/6hCA==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
@@ -1334,8 +1358,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-compiler": {
-      "version": "6.9.0",
-      "integrity": "sha512-UXQ5pomb+Fw48Ch1mJoN1JkDy0loZX8nZKXjy4qxY2s9FMwNOwKJP9wPomAVlYcuzq6u8Viqh5j70ty8ciGWGg==",
+      "version": "6.9.2",
+      "integrity": "sha512-Qv7Zb3RhG92WVm1AjHEJaYbOi3tNT051/EWPYTsYdUe5epYXbR4dJfGpD1eEgo82ThrKCFx0BZfT0b28t0/vqg==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "bin": {
@@ -1357,8 +1381,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/cds-mtxs": {
-      "version": "3.9.0",
-      "integrity": "sha512-U9H9NXQxlxSNwSD/6U59+Egn9LIE2SRdu8i5bZqEG2GB4xEU6csduy0kY4EWvi8XXD8onbFSgw4AA9SB4pN0Yg==",
+      "version": "3.9.3",
+      "integrity": "sha512-NdL+ctu1YmxRMFFk8ip3PZHXxIrDv93gK+ZUE+e5B+9MNDvalQcav4QllqwiGJ/CJcfJROWGTt+a554A81dxow==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
@@ -1373,9 +1397,9 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/hdi": {
-      "version": "4.8.0",
-      "integrity": "sha512-tkJmY2ffm6mt4/LFwRBihlQkMxNAXa3ngvRe2N/6+qLIsUNdrH/M03S5mkygXq56K+KoVVZYuradajCusMWwsw==",
-      "license": "See LICENSE file",
+      "version": "4.8.1",
+      "integrity": "sha512-LfRtIbtfvMl82a8CwpqPJRRB9hRSVUQyvxualYBEzyNu/phuw6bFGQA5LHVngHsms+y797Icm4tl4X+TEkTtlg==",
+      "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "async": "^3.2.3"
@@ -1426,9 +1450,9 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/@sap/xsenv": {
-      "version": "6.2.0",
-      "integrity": "sha512-8jrsX1OAM3YUqGU+4deggqvkxrBrHAPYEllBX0YJfWNffgxSZKHG75bRd/RV6hxPwulPL0DeHfd2eYJMeY5gdw==",
-      "license": "SEE LICENSE IN LICENSE file",
+      "version": "6.2.1",
+      "integrity": "sha512-R1p7VdD3N3jvdkL8av4vLqF+cTQihTz9mCqqF+oa9rVZvgLaCb4ODyZ1dln5/fBgg1OSuch0ESxu3AqZrXVknw==",
+      "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "debug": "4.4.3",
@@ -1489,8 +1513,8 @@
       "peer": true
     },
     "node_modules/@sap/cds-dk/node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.10.0",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1500,7 +1524,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/@sap/cds-dk/node_modules/bindings": {
@@ -1818,8 +1842,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2376,8 +2400,8 @@
       "peer": true
     },
     "node_modules/@sap/cds-dk/node_modules/node-abi": {
-      "version": "3.89.0",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2514,8 +2538,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/qs": {
-      "version": "6.15.1",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -2636,8 +2660,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/semver": {
-      "version": "7.7.4",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -2921,17 +2945,34 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/type-is": {
-      "version": "2.0.1",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@sap/cds-dk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@sap/cds-dk/node_modules/uglify-js": {
@@ -2999,8 +3040,8 @@
       "peer": true
     },
     "node_modules/@sap/cds-dk/node_modules/ws": {
-      "version": "8.20.0",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3032,8 +3073,8 @@
       }
     },
     "node_modules/@sap/cds-dk/node_modules/yaml": {
-      "version": "2.8.3",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -3055,21 +3096,6 @@
         "@sap/cds": ">=8"
       }
     },
-    "node_modules/@sap/cds/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/@sap/dev-cap-tools": {
       "version": "1.53.3",
       "resolved": "https://registry.npmjs.org/@sap/dev-cap-tools/-/dev-cap-tools-1.53.3.tgz",
@@ -3080,19 +3106,21 @@
       }
     },
     "node_modules/@sap/eslint-plugin-cds": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sap/eslint-plugin-cds/-/eslint-plugin-cds-4.2.1.tgz",
-      "integrity": "sha512-XlXMHw9nn2rlPHKcPfDWat1x+LfvH34jpsDqLOYq/Xq51QcAtAW8H1I9uNc2xCCPJkhXVzUuMp/yvy0Cnc8Mzg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@sap/eslint-plugin-cds/-/eslint-plugin-cds-4.2.4.tgz",
+      "integrity": "sha512-nUZC7nrpe+Eqs1cM8F23sxls7FvyffHTFUHXnxXTeNi1aldcRogkUK+ap7j+F7jupNRa/26Fyf+tyJTQ13yPQQ==",
       "dev": true,
       "license": "See LICENSE file",
       "dependencies": {
-        "@eslint/plugin-kit": "^0.6.0",
-        "semver": "^7.7.1",
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-java": "^0.23.5"
+        "@eslint/plugin-kit": "^0.7.2",
+        "semver": "^7.8.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "tree-sitter": "^0.21.1",
+        "tree-sitter-java": "^0.23.5"
       },
       "peerDependencies": {
         "@sap/cds": ">=9",
@@ -3100,11 +3128,10 @@
       }
     },
     "node_modules/@sap/hdi": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@sap/hdi/-/hdi-4.8.0.tgz",
-      "integrity": "sha512-tkJmY2ffm6mt4/LFwRBihlQkMxNAXa3ngvRe2N/6+qLIsUNdrH/M03S5mkygXq56K+KoVVZYuradajCusMWwsw==",
-      "dev": true,
-      "license": "See LICENSE file",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@sap/hdi/-/hdi-4.8.1.tgz",
+      "integrity": "sha512-LfRtIbtfvMl82a8CwpqPJRRB9hRSVUQyvxualYBEzyNu/phuw6bFGQA5LHVngHsms+y797Icm4tl4X+TEkTtlg==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "async": "^3.2.3"
       },
@@ -3125,17 +3152,16 @@
       }
     },
     "node_modules/@sap/hdi-deploy": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@sap/hdi-deploy/-/hdi-deploy-5.6.1.tgz",
-      "integrity": "sha512-+qQ7qwG8lko303L5yRj2dud/nDAVuVblV/mmzJT44oPbF0Nry18eD2LUS23hFeuxjRa7rYK5YKQ8ffGgWxVrYQ==",
-      "dev": true,
-      "license": "See LICENSE file",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@sap/hdi-deploy/-/hdi-deploy-5.7.0.tgz",
+      "integrity": "sha512-ENBCtCBnJEKBlvC5mQT/G7OAteOENo7ygSeRJgVdz7AHikcHUxegtavXkJtFCJ/PSjpjytFKfGRmG8peUVAmNQ==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@sap/hdi": "^4.8.0",
+        "@sap/hdi": "^4.8.1",
         "@sap/xsenv": "^6.0.0",
         "async": "^3.2.6",
         "dotenv": "^16.4.5",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -3155,11 +3181,10 @@
       }
     },
     "node_modules/@sap/hdi-deploy/node_modules/@sap/xsenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@sap/xsenv/-/xsenv-6.2.0.tgz",
-      "integrity": "sha512-8jrsX1OAM3YUqGU+4deggqvkxrBrHAPYEllBX0YJfWNffgxSZKHG75bRd/RV6hxPwulPL0DeHfd2eYJMeY5gdw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE file",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sap/xsenv/-/xsenv-6.2.1.tgz",
+      "integrity": "sha512-R1p7VdD3N3jvdkL8av4vLqF+cTQihTz9mCqqF+oa9rVZvgLaCb4ODyZ1dln5/fBgg1OSuch0ESxu3AqZrXVknw==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "debug": "4.4.3",
         "node-cache": "^5.1.2",
@@ -3173,7 +3198,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3288,9 +3312,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -3346,18 +3370,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -3419,9 +3443,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3449,6 +3473,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3464,6 +3500,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -3512,13 +3557,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3562,9 +3608,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3572,7 +3618,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -3596,20 +3642,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3858,50 +3904,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cli-progress/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-progress/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -4010,12 +4012,16 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie": {
@@ -4153,7 +4159,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4240,9 +4245,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4286,18 +4291,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "devOptional": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4371,20 +4379,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/espree": {
@@ -4528,6 +4522,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend-shallow": {
@@ -4696,16 +4699,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4849,9 +4852,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -4876,7 +4879,6 @@
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -4931,9 +4933,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4943,9 +4945,9 @@
       }
     },
     "node_modules/hdb": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/hdb/-/hdb-2.27.1.tgz",
-      "integrity": "sha512-xYL/W+fq2TyGHyzm8muolQnw8tdh4+2NQ8mQP2FpLSuhfJ8l0jQNSUZoAXic7NfMEan1Jvf8V1L4blwkgTc6+A==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/hdb/-/hdb-2.29.4.tgz",
+      "integrity": "sha512-9L7/xjx4NU2YWatqLSHXhuEIuvNlV/4eRFg7u/L63U1Dc5LocP4yWeH8UGKTLBCJkt548OQ+A7PqqimZwEuqdw==",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "0.7.0"
@@ -5008,9 +5010,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.15",
@@ -5021,7 +5023,20 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -5114,12 +5129,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5145,6 +5160,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -5582,13 +5606,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.90.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
-      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5598,11 +5621,12 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -5645,6 +5669,7 @@
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -5807,14 +5832,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -5822,7 +5847,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -5834,16 +5859,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -5856,18 +5881,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -5908,9 +5933,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.x"
@@ -6047,12 +6072,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -6225,9 +6251,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6334,14 +6360,14 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6454,7 +6480,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6504,6 +6529,20 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-changelog": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/stringify-changelog/-/stringify-changelog-0.2.1.tgz",
@@ -6518,6 +6557,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6554,9 +6605,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.5.tgz",
-      "integrity": "sha512-7/FQfWe9A4qoyYFdAwy0chD0uDYidDp/ZT9VQ9LZlgD4AnnHJk8/+ytAA1HkJYOPySmK6helPDdJQMlcumt7HA==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -6645,6 +6696,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -6657,6 +6709,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^8.2.2",
         "node-gyp-build": "^4.8.2"
@@ -6705,24 +6758,27 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -6733,9 +6789,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6764,9 +6820,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6887,7 +6943,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -6925,6 +6980,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/cap/package.json
+++ b/cap/package.json
@@ -6,16 +6,16 @@
   "license": "Apache-2.0",
   "private": false,
   "dependencies": {
-    "@cap-js-community/odata-v2-adapter": "^1.15.10",
-    "@cap-js/change-tracking": "^2.0.0-beta.11",
-    "@cap-js/graphql": "0.14.0",
+    "@cap-js-community/odata-v2-adapter": "^1.15.12",
+    "@cap-js/change-tracking": "^2.0.1",
+    "@cap-js/graphql": "^0.14.0",
     "@cap-js/hana": "^2.7.0",
-    "@cap-js/notifications": "0.3.0",
-    "@cap-js/ord": "1.6.0",
+    "@cap-js/notifications": "^0.3.0",
+    "@cap-js/ord": "^1.9.0",
     "@cap-js/postgres": "^2.2.0",
     "@cap-js/sqlite": "^2.2.0",
     "@cap-js/telemetry": "^1.6.0",
-    "@sap-cloud-sdk/resilience": "^4.6.0",
+    "@sap-cloud-sdk/resilience": "^4.7.0",
     "@sap/cds": "^9.9.1",
     "@sap/cds-common-content": "^3.1.0",
     "@sap/cds-fiori": "^2.3.0",
@@ -23,7 +23,7 @@
     "cds-swagger-ui-express": "^0.11.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.1"
   },
   "engines": {
     "node": ">=22"
@@ -168,15 +168,22 @@
   },
   "devDependencies": {
     "@cap-js/cds-test": "^1.0.1",
-    "@cap-js/cds-typer": ">=0.1",
+    "@cap-js/cds-typer": "^0.40.0",
     "@sap/dev-cap-tools": "^1.53.2",
-    "@sap/eslint-plugin-cds": "^4.2.1",
-    "@sap/hdi-deploy": "^5.6.1",
-    "eslint": "^10.3.0",
+    "@sap/eslint-plugin-cds": "^4.2.4",
+    "@sap/hdi-deploy": "^5.7.0",
+    "eslint": "^10.5.0",
     "stringify-changelog": "^0.2.1"
   },
   "overrides": {
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.6",
+    "@sap/cds-dk": {
+      "qs": "^6.15.3",
+      "ws": "^8.21.0",
+      "express": {
+        "qs": "^6.15.3"
+      }
+    }
   },
   "imports": {
     "#cds-models/*": "./@cds-models/*/index.js"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,10 +10,10 @@
         "tone": "^15.1.22"
       },
       "devDependencies": {
-        "mermaid": "^11.13.0",
-        "vitepress": "^1.6.0",
+        "mermaid": "^11.16.0",
+        "vitepress": "^1.6.4",
         "vitepress-plugin-mermaid": "^2.0.17",
-        "vue": "^3.5.0"
+        "vue": "^3.5.39"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -309,13 +309,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -334,14 +334,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -865,13 +865,13 @@
       "optional": true
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -966,6 +966,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -980,6 +983,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -994,6 +1000,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1008,6 +1017,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,6 +1034,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,6 +1051,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,6 +1068,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1064,6 +1085,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,6 +1102,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,6 +1119,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1106,6 +1136,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,6 +1153,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1170,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1719,57 +1758,57 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1809,57 +1848,57 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.33"
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.5.33"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2714,9 +2753,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -3024,27 +3063,27 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -3285,9 +3324,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3305,7 +3344,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3845,17 +3884,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/site/package.json
+++ b/site/package.json
@@ -8,13 +8,16 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "mermaid": "^11.13.0",
-    "vitepress": "^1.6.0",
+    "mermaid": "^11.16.0",
+    "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17",
-    "vue": "^3.5.0"
+    "vue": "^3.5.39"
   },
   "dependencies": {
     "@tonejs/midi": "^2.0.28",
     "tone": "^15.1.22"
+  },
+  "overrides": {
+    "dompurify": "^3.4.11"
   }
 }


### PR DESCRIPTION
## Summary

Updates dependencies across `cap/` and `site/` workspaces and resolves as many security advisories as upstream allows. All 72 tests still pass.

## cap/ — direct dep updates

| Package | Old | New |
|---|---|---|
| `@cap-js-community/odata-v2-adapter` | `^1.15.10` | `^1.15.12` |
| `@cap-js/change-tracking` | `^2.0.0-beta.11` | `^2.0.1` *(out of beta)* |
| `@cap-js/graphql` | `0.14.0` | `^0.14.0` *(caret-ranged)* |
| `@cap-js/notifications` | `0.3.0` | `^0.3.0` *(caret-ranged)* |
| `@cap-js/ord` | `1.6.0` | `^1.9.0` |
| `@sap-cloud-sdk/resilience` | `^4.6.0` | `^4.7.0` |
| `uuid` | `^14.0.0` | `^14.0.1` |
| `@cap-js/cds-typer` (dev) | `>=0.1` | `^0.40.0` *(pinned)* |
| `@sap/eslint-plugin-cds` (dev) | `^4.2.1` | `^4.2.4` |
| `@sap/hdi-deploy` (dev) | `^5.6.1` | `^5.7.0` |
| `eslint` (dev) | `^10.3.0` | `^10.5.0` |

### Security — cap/: 15 → 9 vulnerabilities (10 moderate + 5 high → **9 moderate, 0 high**)

- Added nested override for `@sap/cds-dk` to force `qs ^6.15.3` and `ws ^8.21.0`, eliminating the high-severity `ws` memory disclosure + `qs` DoS.
- `npm audit fix` resolved 4 more advisories (axios SSRF/CRLF, form-data CRLF, http-proxy-middleware, piscina prototype-pollution RCE).
- **9 remaining** are all `@opentelemetry/*` advisories flowing through `@cap-js/telemetry` (W3C Baggage unbounded memory allocation, CVSS 5.3). **No upstream fix yet** — requires `@cap-js/telemetry` to ship with `@opentelemetry/core ≥2.8.0`. Worth filing a tracking issue with cap-js/telemetry.

## site/ — direct dep updates

| Package | Old | New |
|---|---|---|
| `mermaid` | `^11.13.0` | `^11.16.0` |
| `vitepress` | `^1.6.0` | `^1.6.4` |
| `vue` | `^3.5.0` | `^3.5.39` |

### Security — site/: 5 → 4 vulnerabilities

- Added override `dompurify: ^3.4.11` (transitive via mermaid) to clear 8 DOMPurify XSS advisories.
- **4 remaining** are dev-server-only `vite`/`esbuild` path-traversal/dev-server issues. `vitepress@1.x` pins `vite@^5.4.x`; the only real fix is `vitepress 2.x` (still alpha). These do not affect the built static site.

## Not touched

- CAP runtime (`@sap/cds ^9.9.1`) — at published latest. **CAP 10 ships this month (June 2026)**; leaving the runtime untouched until the CAP 10 migration is intentional.

## Verification

- `npm test` in `cap/` — all **72 tests pass** ✅
- `npm audit` rerun in both workspaces